### PR TITLE
Minor colour fix.

### DIFF
--- a/themes/Uprise/style.css
+++ b/themes/Uprise/style.css
@@ -403,7 +403,6 @@ h2 {
 	margin-top:-6px;
 	padding-top:10px;
 	text-align: center;
-	color:#FFFF;
 	font-family:"Trebuchet MS"
 }
 


### PR DESCRIPTION
Removes duplicate and invalid color entry - which was making all headers on this theme white and therefore hard to see due to them already having a light background.